### PR TITLE
Add cache-dit to Community Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ We are excited to release the distilled version of [Qwen-Image](https://github.c
 * [Diffusers](https://github.com/huggingface/diffusers) now supports loading Qwen-Image-Lightning within the Qwen-Image pipeline. Please check [their documentation](https://huggingface.co/docs/diffusers/main/api/pipelines/qwenimage) for details.
 * [ComfyUI](https://github.com/comfyanonymous/ComfyUI) provides native workflows for [Qwen-Image](https://docs.comfy.org/tutorials/image/qwen/qwen-image) and [Qwen-Image-Edit](https://docs.comfy.org/tutorials/image/qwen/qwen-image-edit), including Lightning LoRA weights.
 * [Nunchaku](https://github.com/nunchaku-tech/nunchaku) has released 4-bit [Qwen-Image lightning](https://huggingface.co/nunchaku-tech/nunchaku-qwen-image). Try their [example script](https://github.com/nunchaku-tech/nunchaku/blob/main/examples/v1/qwen-image-lightning.py) to reduce inference GPU memory usage.
-* [cache-dit](https://github.com/vipshop/cache-dit) now supports [Qwen-Image-Lightning](https://github.com/vipshop/cache-dit/blob/main/examples/pipeline/run_qwen_image_lightning.py) **3.5** steps inference with cache. Please check their [example script](https://github.com/vipshop/cache-dit/blob/main/examples/pipeline/run_qwen_image_lightning.py) for details.
+* [cache-dit](https://github.com/vipshop/cache-dit) now supports **3.5** steps inference for [Qwen-Image-Lightning](https://github.com/vipshop/cache-dit/blob/main/examples/pipeline/run_qwen_image_lightning.py) with cache acceleration.
 
 ## 📑 Todo List
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ We are excited to release the distilled version of [Qwen-Image](https://github.c
 * [Diffusers](https://github.com/huggingface/diffusers) now supports loading Qwen-Image-Lightning within the Qwen-Image pipeline. Please check [their documentation](https://huggingface.co/docs/diffusers/main/api/pipelines/qwenimage) for details.
 * [ComfyUI](https://github.com/comfyanonymous/ComfyUI) provides native workflows for [Qwen-Image](https://docs.comfy.org/tutorials/image/qwen/qwen-image) and [Qwen-Image-Edit](https://docs.comfy.org/tutorials/image/qwen/qwen-image-edit), including Lightning LoRA weights.
 * [Nunchaku](https://github.com/nunchaku-tech/nunchaku) has released 4-bit [Qwen-Image lightning](https://huggingface.co/nunchaku-tech/nunchaku-qwen-image). Try their [example script](https://github.com/nunchaku-tech/nunchaku/blob/main/examples/v1/qwen-image-lightning.py) to reduce inference GPU memory usage.
+* [cache-dit](https://github.com/vipshop/cache-dit) now supports [Qwen-Image-Lightning](https://github.com/vipshop/cache-dit/blob/main/examples/pipeline/run_qwen_image_lightning.py) **3.5** steps inference with cache. Please check their [example script](https://github.com/vipshop/cache-dit/blob/main/examples/pipeline/run_qwen_image_lightning.py) for details.
 
 ## 📑 Todo List
 


### PR DESCRIPTION
[cache-dit](https://github.com/vipshop/cache-dit) now supports [Qwen-Image-Lightning](https://github.com/vipshop/cache-dit/blob/main/examples/pipeline/run_qwen_image_lightning.py) **3.5** steps inference with cache. Please check their [example script](https://github.com/vipshop/cache-dit/blob/main/examples/pipeline/run_qwen_image_lightning.py) for details.

<div align="center">
<img src=https://github.com/vipshop/cache-dit/raw/main/assets/qwen-image-lightning.4steps.C0_L1_Q0_NONE.png width=200px>
  <img src=https://github.com/vipshop/cache-dit/raw/main/assets/qwen-image-lightning.4steps.C0_L1_Q0_DBCACHE_F16B16_W2M1MC1_T0O2_R0.9_S1.png width=200px>
  <p><b>🔥Qwen-Image-Lightning</b> 4 steps | <b><a href="https://github.com/vipshop/cache-dit">+cache-dit</a></b> 3.5 steps:<b>~1.14x↑🎉</b>
</div>  

@X-niper @HamQiuZ 