### PR TITLE
Add workflows/qwen-image-edit-2509-4steps-gguf.json

### DIFF
--- a/workflows/qwen-image-edit-2509-4steps-gguf.json
+++ b/workflows/qwen-image-edit-2509-4steps-gguf.json
@@ -141,7 +141,7 @@
         "Node name for S&R": "PrimitiveStringMultiline"
       },
       "widgets_values": [
-        "Make skirt in image 1 white, blue eyes, and right eye fully closed. Put on the necklace in image 2, it should be relativelly small. Make girl look to the right. Make the shirt pink having a nice mandala pattern on it"
+        "Make skirt in image 1 white, blue eyes, and right eye fully closed. Put on the necklace in image 2, it should be relatively small. Make girl look to the right. Make the shirt pink having a nice mandala pattern on it"
       ]
     },
     {


### PR DESCRIPTION
Since in mac there is no support for fp8_e4m3fn, this end wasting a lot of memory, and in a Mac M1 Max 64 GB, it is not possible to run the workflow without swapping memory. The only way I was be able to use reasonably the qwen3 lighting edit was by using Draw Things (that doesn't support multiple image input right now).

This PR adds a comfyui workflow that loads both: the main model and the CLIP in GGUF format and loads the lora normally. This allows to execute the workflow within 64GB of RAM.


<img width="1444" height="937" alt="Captura de pantalla 2025-12-03 a las 0 25 14" src="https://github.com/user-attachments/assets/80976826-950c-4bdf-883c-e9653e707fef" />

<img width="1444" height="937" alt="Captura de pantalla 2025-12-03 a las 0 34 38" src="https://github.com/user-attachments/assets/fb556c5d-8a90-4f00-b09d-8786c7f8a2b0" />
